### PR TITLE
upgrade the k8s java client to 18.0.1 to be compatible with Kubernetes 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You should also add the dependency of Kubernetes official java SDK:
 <dependency>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java</artifactId>
-    <version>11.0.1</version>
+    <version>18.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>client-java</artifactId>
     <packaging>jar</packaging>
     <name>client-java</name>
-    <version>1.4.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <url>https://github.com/openkruise/client-java</url>
     <description>Jave Client For OpenKruise</description>
 
@@ -26,24 +26,23 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <name>Siyu Wang</name>
-            <email>FillZpp.pub@gmail.com</email>
-            <organization>OpenKruise</organization>
-            <organizationUrl>http://openkruise.io</organizationUrl>
-        </developer>
-    </developers>
+    <contributors>
+        <contributor>
+            <properties>
+                <provider>mowu.wd@alibaba-inc.com</provider>
+            </properties>
+        </contributor>
+    </contributors>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>releases</id>
+            <url>http://repo.alibaba-inc.com/mvn/releases</url>
         </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <url>http://repo.alibaba-inc.com/mvn/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <build>
@@ -225,7 +224,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <k8s.client.version>14.0.0</k8s.client.version>
+        <k8s.client.version>18.0.1</k8s.client.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -238,3 +237,4 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -26,23 +26,24 @@
         </license>
     </licenses>
 
-    <contributors>
-        <contributor>
-            <properties>
-                <provider>mowu.wd@alibaba-inc.com</provider>
-            </properties>
-        </contributor>
-    </contributors>
+    <developers>
+        <developer>
+            <name>Siyu Wang</name>
+            <email>FillZpp.pub@gmail.com</email>
+            <organization>OpenKruise</organization>
+            <organizationUrl>http://openkruise.io</organizationUrl>
+        </developer>
+    </developers>
 
     <distributionManagement>
-        <repository>
-            <id>releases</id>
-            <url>http://repo.alibaba-inc.com/mvn/releases</url>
-        </repository>
         <snapshotRepository>
-            <id>snapshots</id>
-            <url>http://repo.alibaba-inc.com/mvn/snapshots</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
     <build>

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1AdvancedCronJobStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1AdvancedCronJobStatus.java
@@ -17,11 +17,12 @@ import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * AdvancedCronJobStatus defines the observed state of AdvancedCronJob
@@ -33,7 +34,7 @@ public class KruiseAppsV1alpha1AdvancedCronJobStatus {
   private List<V1ObjectReference> active = null;
 
   @SerializedName("lastScheduleTime")
-  private DateTime lastScheduleTime = null;
+  private OffsetDateTime lastScheduleTime = null;
 
   @SerializedName("type")
   private String type = null;
@@ -64,7 +65,7 @@ public class KruiseAppsV1alpha1AdvancedCronJobStatus {
     this.active = active;
   }
 
-  public KruiseAppsV1alpha1AdvancedCronJobStatus lastScheduleTime(DateTime lastScheduleTime) {
+  public KruiseAppsV1alpha1AdvancedCronJobStatus lastScheduleTime(OffsetDateTime lastScheduleTime) {
     this.lastScheduleTime = lastScheduleTime;
     return this;
   }
@@ -74,11 +75,11 @@ public class KruiseAppsV1alpha1AdvancedCronJobStatus {
    * @return lastScheduleTime
   **/
   @ApiModelProperty(value = "Information when was the last time the job was successfully scheduled.")
-  public DateTime getLastScheduleTime() {
+  public OffsetDateTime getLastScheduleTime() {
     return lastScheduleTime;
   }
 
-  public void setLastScheduleTime(DateTime lastScheduleTime) {
+  public void setLastScheduleTime(OffsetDateTime lastScheduleTime) {
     this.lastScheduleTime = lastScheduleTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1BroadcastJobStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1BroadcastJobStatus.java
@@ -16,11 +16,12 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * BroadcastJobStatus defines the observed state of BroadcastJob
@@ -32,7 +33,7 @@ public class KruiseAppsV1alpha1BroadcastJobStatus {
   private Integer active = null;
 
   @SerializedName("completionTime")
-  private DateTime completionTime = null;
+  private OffsetDateTime completionTime = null;
 
   @SerializedName("conditions")
   private List<KruiseAppsV1alpha1JobCondition> conditions = null;
@@ -47,7 +48,7 @@ public class KruiseAppsV1alpha1BroadcastJobStatus {
   private String phase = null;
 
   @SerializedName("startTime")
-  private DateTime startTime = null;
+  private OffsetDateTime startTime = null;
 
   @SerializedName("succeeded")
   private Integer succeeded = null;
@@ -70,7 +71,7 @@ public class KruiseAppsV1alpha1BroadcastJobStatus {
     this.active = active;
   }
 
-  public KruiseAppsV1alpha1BroadcastJobStatus completionTime(DateTime completionTime) {
+  public KruiseAppsV1alpha1BroadcastJobStatus completionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
     return this;
   }
@@ -80,11 +81,11 @@ public class KruiseAppsV1alpha1BroadcastJobStatus {
    * @return completionTime
   **/
   @ApiModelProperty(value = "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getCompletionTime() {
+  public OffsetDateTime getCompletionTime() {
     return completionTime;
   }
 
-  public void setCompletionTime(DateTime completionTime) {
+  public void setCompletionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
   }
 
@@ -168,7 +169,7 @@ public class KruiseAppsV1alpha1BroadcastJobStatus {
     this.phase = phase;
   }
 
-  public KruiseAppsV1alpha1BroadcastJobStatus startTime(DateTime startTime) {
+  public KruiseAppsV1alpha1BroadcastJobStatus startTime(OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -178,11 +179,11 @@ public class KruiseAppsV1alpha1BroadcastJobStatus {
    * @return startTime
   **/
   @ApiModelProperty(value = "Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getStartTime() {
+  public OffsetDateTime getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(DateTime startTime) {
+  public void setStartTime(OffsetDateTime startTime) {
     this.startTime = startTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1CloneSetCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1CloneSetCondition.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * CloneSetCondition describes the state of a CloneSet at a certain point.
@@ -27,7 +28,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1CloneSetCondition {
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -41,7 +42,7 @@ public class KruiseAppsV1alpha1CloneSetCondition {
   @SerializedName("type")
   private String type = null;
 
-  public KruiseAppsV1alpha1CloneSetCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1CloneSetCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -51,11 +52,11 @@ public class KruiseAppsV1alpha1CloneSetCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ContainerProbeState.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ContainerProbeState.java
@@ -15,9 +15,10 @@ package io.openkruise.client.models;
 
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * KruiseAppsV1alpha1NodePodProbeStatusProbeStates
@@ -25,10 +26,10 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1ContainerProbeState {
   @SerializedName("lastProbeTime")
-  private DateTime lastProbeTime = null;
+  private OffsetDateTime lastProbeTime = null;
 
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -39,7 +40,7 @@ public class KruiseAppsV1alpha1ContainerProbeState {
   @SerializedName("state")
   private String state = null;
 
-  public KruiseAppsV1alpha1ContainerProbeState lastProbeTime(DateTime lastProbeTime) {
+  public KruiseAppsV1alpha1ContainerProbeState lastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
     return this;
   }
@@ -49,15 +50,15 @@ public class KruiseAppsV1alpha1ContainerProbeState {
    * @return lastProbeTime
   **/
   @ApiModelProperty(value = "Last time we probed the condition.")
-  public DateTime getLastProbeTime() {
+  public OffsetDateTime getLastProbeTime() {
     return lastProbeTime;
   }
 
-  public void setLastProbeTime(DateTime lastProbeTime) {
+  public void setLastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
   }
 
-  public KruiseAppsV1alpha1ContainerProbeState lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1ContainerProbeState lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -67,11 +68,11 @@ public class KruiseAppsV1alpha1ContainerProbeState {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ContainerRecreateRequestContainer.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ContainerRecreateRequestContainer.java
@@ -15,7 +15,6 @@ package io.openkruise.client.models;
 
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
-import io.kubernetes.client.openapi.models.V1Handler;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
@@ -36,7 +35,7 @@ public class KruiseAppsV1alpha1ContainerRecreateRequestContainer {
   private List<V1ContainerPort> ports = null;
 
   @SerializedName("preStop")
-  private V1Handler preStop = null;
+  private ProbeHandler preStop = null;
 
   @SerializedName("statusContext")
   private KruiseAppsV1alpha1ContainerRecreateRequestContext statusContext = null;
@@ -85,7 +84,7 @@ public class KruiseAppsV1alpha1ContainerRecreateRequestContainer {
     this.ports = ports;
   }
 
-  public KruiseAppsV1alpha1ContainerRecreateRequestContainer preStop(V1Handler preStop) {
+  public KruiseAppsV1alpha1ContainerRecreateRequestContainer preStop(ProbeHandler preStop) {
     this.preStop = preStop;
     return this;
   }
@@ -95,11 +94,11 @@ public class KruiseAppsV1alpha1ContainerRecreateRequestContainer {
    * @return preStop
   **/
   @ApiModelProperty(value = "")
-  public V1Handler getPreStop() {
+  public ProbeHandler getPreStop() {
     return preStop;
   }
 
-  public void setPreStop(V1Handler preStop) {
+  public void setPreStop(ProbeHandler preStop) {
     this.preStop = preStop;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ContainerRecreateRequestStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ContainerRecreateRequestStatus.java
@@ -16,11 +16,12 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * ContainerRecreateRequestStatus defines the observed state of ContainerRecreateRequest
@@ -29,7 +30,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1ContainerRecreateRequestStatus {
   @SerializedName("completionTime")
-  private DateTime completionTime = null;
+  private OffsetDateTime completionTime = null;
 
   @SerializedName("containerRecreateStates")
   private List<KruiseAppsV1alpha1ContainerRecreateRequestContainerRecreateState> containerRecreateStates = null;
@@ -40,7 +41,7 @@ public class KruiseAppsV1alpha1ContainerRecreateRequestStatus {
   @SerializedName("phase")
   private String phase = null;
 
-  public KruiseAppsV1alpha1ContainerRecreateRequestStatus completionTime(DateTime completionTime) {
+  public KruiseAppsV1alpha1ContainerRecreateRequestStatus completionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
     return this;
   }
@@ -50,11 +51,11 @@ public class KruiseAppsV1alpha1ContainerRecreateRequestStatus {
    * @return completionTime
   **/
   @ApiModelProperty(value = "Represents time when the ContainerRecreateRequest was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getCompletionTime() {
+  public OffsetDateTime getCompletionTime() {
     return completionTime;
   }
 
-  public void setCompletionTime(DateTime completionTime) {
+  public void setCompletionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1CronJobTemplate.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1CronJobTemplate.java
@@ -14,7 +14,7 @@
 package io.openkruise.client.models;
 
 import com.google.gson.annotations.SerializedName;
-import io.kubernetes.client.openapi.models.V1beta1JobTemplateSpec;
+import io.kubernetes.client.openapi.models.V1JobTemplateSpec;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
@@ -30,7 +30,7 @@ public class KruiseAppsV1alpha1CronJobTemplate {
   private KruiseAppsV1alpha1BroadcastJobSpec broadcastJobTemplate = null;
 
   @SerializedName("jobTemplate")
-  private V1beta1JobTemplateSpec jobTemplate = null;
+  private V1JobTemplateSpec jobTemplate = null;
 
   public KruiseAppsV1alpha1CronJobTemplate broadcastJobTemplate(KruiseAppsV1alpha1BroadcastJobSpec broadcastJobTemplate) {
     this.broadcastJobTemplate = broadcastJobTemplate;
@@ -50,7 +50,7 @@ public class KruiseAppsV1alpha1CronJobTemplate {
     this.broadcastJobTemplate = broadcastJobTemplate;
   }
 
-  public KruiseAppsV1alpha1CronJobTemplate jobTemplate(V1beta1JobTemplateSpec jobTemplate) {
+  public KruiseAppsV1alpha1CronJobTemplate jobTemplate(V1JobTemplateSpec jobTemplate) {
     this.jobTemplate = jobTemplate;
     return this;
   }
@@ -60,11 +60,11 @@ public class KruiseAppsV1alpha1CronJobTemplate {
    * @return jobTemplate
   **/
   @ApiModelProperty(value = "Specifies the job that will be created when executing a CronJob.")
-  public V1beta1JobTemplateSpec getJobTemplate() {
+  public V1JobTemplateSpec getJobTemplate() {
     return jobTemplate;
   }
 
-  public void setJobTemplate(V1beta1JobTemplateSpec jobTemplate) {
+  public void setJobTemplate(V1JobTemplateSpec jobTemplate) {
     this.jobTemplate = jobTemplate;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1DaemonSetCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1DaemonSetCondition.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * DaemonSetCondition describes the state of a DaemonSet at a certain point.
@@ -27,7 +28,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1DaemonSetCondition {
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -41,7 +42,7 @@ public class KruiseAppsV1alpha1DaemonSetCondition {
   @SerializedName("type")
   private String type = null;
 
-  public KruiseAppsV1alpha1DaemonSetCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1DaemonSetCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -51,11 +52,11 @@ public class KruiseAppsV1alpha1DaemonSetCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1EphemeralJobStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1EphemeralJobStatus.java
@@ -16,11 +16,12 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * EphemeralJobStatus defines the observed state of EphemeralJob
@@ -29,7 +30,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1EphemeralJobStatus {
   @SerializedName("completionTime")
-  private DateTime completionTime = null;
+  private OffsetDateTime completionTime = null;
 
   @SerializedName("conditions")
   private List<KruiseAppsV1alpha1JobCondition> conditions = null;
@@ -47,7 +48,7 @@ public class KruiseAppsV1alpha1EphemeralJobStatus {
   private Integer running = null;
 
   @SerializedName("startTime")
-  private DateTime startTime = null;
+  private OffsetDateTime startTime = null;
 
   @SerializedName("succeeded")
   private Integer succeeded = null;
@@ -55,7 +56,7 @@ public class KruiseAppsV1alpha1EphemeralJobStatus {
   @SerializedName("waiting")
   private Integer waiting = null;
 
-  public KruiseAppsV1alpha1EphemeralJobStatus completionTime(DateTime completionTime) {
+  public KruiseAppsV1alpha1EphemeralJobStatus completionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
     return this;
   }
@@ -65,11 +66,11 @@ public class KruiseAppsV1alpha1EphemeralJobStatus {
    * @return completionTime
   **/
   @ApiModelProperty(value = "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getCompletionTime() {
+  public OffsetDateTime getCompletionTime() {
     return completionTime;
   }
 
-  public void setCompletionTime(DateTime completionTime) {
+  public void setCompletionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
   }
 
@@ -171,7 +172,7 @@ public class KruiseAppsV1alpha1EphemeralJobStatus {
     this.running = running;
   }
 
-  public KruiseAppsV1alpha1EphemeralJobStatus startTime(DateTime startTime) {
+  public KruiseAppsV1alpha1EphemeralJobStatus startTime(OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -181,11 +182,11 @@ public class KruiseAppsV1alpha1EphemeralJobStatus {
    * @return startTime
   **/
   @ApiModelProperty(value = "Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getStartTime() {
+  public OffsetDateTime getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(DateTime startTime) {
+  public void setStartTime(OffsetDateTime startTime) {
     this.startTime = startTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImageListPullJobStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImageListPullJobStatus.java
@@ -16,11 +16,12 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * ImageListPullJobStatus defines the observed state of ImageListPullJob
@@ -35,7 +36,7 @@ public class KruiseAppsV1alpha1ImageListPullJobStatus {
   private Integer completed = null;
 
   @SerializedName("completionTime")
-  private DateTime completionTime = null;
+  private OffsetDateTime completionTime = null;
 
   @SerializedName("desired")
   private Integer desired = null;
@@ -44,7 +45,7 @@ public class KruiseAppsV1alpha1ImageListPullJobStatus {
   private List<KruiseAppsV1alpha1FailedImageStatus> failedImageStatuses = null;
 
   @SerializedName("startTime")
-  private DateTime startTime = null;
+  private OffsetDateTime startTime = null;
 
   @SerializedName("succeeded")
   private Integer succeeded = null;
@@ -85,7 +86,7 @@ public class KruiseAppsV1alpha1ImageListPullJobStatus {
     this.completed = completed;
   }
 
-  public KruiseAppsV1alpha1ImageListPullJobStatus completionTime(DateTime completionTime) {
+  public KruiseAppsV1alpha1ImageListPullJobStatus completionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
     return this;
   }
@@ -95,11 +96,11 @@ public class KruiseAppsV1alpha1ImageListPullJobStatus {
    * @return completionTime
   **/
   @ApiModelProperty(value = "Represents time when the all the image pull job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getCompletionTime() {
+  public OffsetDateTime getCompletionTime() {
     return completionTime;
   }
 
-  public void setCompletionTime(DateTime completionTime) {
+  public void setCompletionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
   }
 
@@ -147,7 +148,7 @@ public class KruiseAppsV1alpha1ImageListPullJobStatus {
     this.failedImageStatuses = failedImageStatuses;
   }
 
-  public KruiseAppsV1alpha1ImageListPullJobStatus startTime(DateTime startTime) {
+  public KruiseAppsV1alpha1ImageListPullJobStatus startTime(OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -157,11 +158,11 @@ public class KruiseAppsV1alpha1ImageListPullJobStatus {
    * @return startTime
   **/
   @ApiModelProperty(value = "Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getStartTime() {
+  public OffsetDateTime getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(DateTime startTime) {
+  public void setStartTime(OffsetDateTime startTime) {
     this.startTime = startTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImagePullJobStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImagePullJobStatus.java
@@ -21,12 +21,12 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * ImagePullJobStatus defines the observed state of ImagePullJob
@@ -38,7 +38,7 @@ public class KruiseAppsV1alpha1ImagePullJobStatus {
   private Integer active = null;
 
   @SerializedName("completionTime")
-  private DateTime completionTime = null;
+  private OffsetDateTime completionTime = null;
 
   @SerializedName("desired")
   private Integer desired = null;
@@ -53,7 +53,7 @@ public class KruiseAppsV1alpha1ImagePullJobStatus {
   private String message = null;
 
   @SerializedName("startTime")
-  private DateTime startTime = null;
+  private OffsetDateTime startTime = null;
 
   @SerializedName("succeeded")
   private Integer succeeded = null;
@@ -76,7 +76,7 @@ public class KruiseAppsV1alpha1ImagePullJobStatus {
     this.active = active;
   }
 
-  public KruiseAppsV1alpha1ImagePullJobStatus completionTime(DateTime completionTime) {
+  public KruiseAppsV1alpha1ImagePullJobStatus completionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
     return this;
   }
@@ -86,11 +86,11 @@ public class KruiseAppsV1alpha1ImagePullJobStatus {
    * @return completionTime
   **/
   @ApiModelProperty(value = "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getCompletionTime() {
+  public OffsetDateTime getCompletionTime() {
     return completionTime;
   }
 
-  public void setCompletionTime(DateTime completionTime) {
+  public void setCompletionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
   }
 
@@ -174,7 +174,7 @@ public class KruiseAppsV1alpha1ImagePullJobStatus {
     this.message = message;
   }
 
-  public KruiseAppsV1alpha1ImagePullJobStatus startTime(DateTime startTime) {
+  public KruiseAppsV1alpha1ImagePullJobStatus startTime(OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -184,11 +184,11 @@ public class KruiseAppsV1alpha1ImagePullJobStatus {
    * @return startTime
   **/
   @ApiModelProperty(value = "Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getStartTime() {
+  public OffsetDateTime getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(DateTime startTime) {
+  public void setStartTime(OffsetDateTime startTime) {
     this.startTime = startTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImageTagSpec.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImageTagSpec.java
@@ -17,11 +17,12 @@ import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * ImageTagSpec defines the pulling spec of an image tag
@@ -30,7 +31,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1ImageTagSpec {
   @SerializedName("createdAt")
-  private DateTime createdAt = null;
+  private OffsetDateTime createdAt = null;
 
   @SerializedName("ownerReferences")
   private List<V1ObjectReference> ownerReferences = null;
@@ -44,7 +45,7 @@ public class KruiseAppsV1alpha1ImageTagSpec {
   @SerializedName("version")
   private Long version = null;
 
-  public KruiseAppsV1alpha1ImageTagSpec createdAt(DateTime createdAt) {
+  public KruiseAppsV1alpha1ImageTagSpec createdAt(OffsetDateTime createdAt) {
     this.createdAt = createdAt;
     return this;
   }
@@ -54,11 +55,11 @@ public class KruiseAppsV1alpha1ImageTagSpec {
    * @return createdAt
   **/
   @ApiModelProperty(value = "Specifies the create time of this tag")
-  public DateTime getCreatedAt() {
+  public OffsetDateTime getCreatedAt() {
     return createdAt;
   }
 
-  public void setCreatedAt(DateTime createdAt) {
+  public void setCreatedAt(OffsetDateTime createdAt) {
     this.createdAt = createdAt;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImageTagStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ImageTagStatus.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * ImageTagStatus defines the pulling status of an image tag
@@ -27,7 +28,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1ImageTagStatus {
   @SerializedName("completionTime")
-  private DateTime completionTime = null;
+  private OffsetDateTime completionTime = null;
 
   @SerializedName("imageID")
   private String imageID = null;
@@ -42,7 +43,7 @@ public class KruiseAppsV1alpha1ImageTagStatus {
   private Integer progress = null;
 
   @SerializedName("startTime")
-  private DateTime startTime = null;
+  private OffsetDateTime startTime = null;
 
   @SerializedName("tag")
   private String tag = null;
@@ -50,7 +51,7 @@ public class KruiseAppsV1alpha1ImageTagStatus {
   @SerializedName("version")
   private Long version = null;
 
-  public KruiseAppsV1alpha1ImageTagStatus completionTime(DateTime completionTime) {
+  public KruiseAppsV1alpha1ImageTagStatus completionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
     return this;
   }
@@ -60,11 +61,11 @@ public class KruiseAppsV1alpha1ImageTagStatus {
    * @return completionTime
   **/
   @ApiModelProperty(value = "Represents time when the pulling task was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getCompletionTime() {
+  public OffsetDateTime getCompletionTime() {
     return completionTime;
   }
 
-  public void setCompletionTime(DateTime completionTime) {
+  public void setCompletionTime(OffsetDateTime completionTime) {
     this.completionTime = completionTime;
   }
 
@@ -140,7 +141,7 @@ public class KruiseAppsV1alpha1ImageTagStatus {
     this.progress = progress;
   }
 
-  public KruiseAppsV1alpha1ImageTagStatus startTime(DateTime startTime) {
+  public KruiseAppsV1alpha1ImageTagStatus startTime(OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -150,11 +151,11 @@ public class KruiseAppsV1alpha1ImageTagStatus {
    * @return startTime
   **/
   @ApiModelProperty(value = "Represents time when the pulling task was acknowledged by the image puller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.")
-  public DateTime getStartTime() {
+  public OffsetDateTime getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(DateTime startTime) {
+  public void setStartTime(OffsetDateTime startTime) {
     this.startTime = startTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1JobCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1JobCondition.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * JobCondition describes current state of a job.
@@ -27,10 +28,10 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1JobCondition {
   @SerializedName("lastProbeTime")
-  private DateTime lastProbeTime = null;
+  private OffsetDateTime lastProbeTime = null;
 
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -44,7 +45,7 @@ public class KruiseAppsV1alpha1JobCondition {
   @SerializedName("type")
   private String type = null;
 
-  public KruiseAppsV1alpha1JobCondition lastProbeTime(DateTime lastProbeTime) {
+  public KruiseAppsV1alpha1JobCondition lastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
     return this;
   }
@@ -54,15 +55,15 @@ public class KruiseAppsV1alpha1JobCondition {
    * @return lastProbeTime
   **/
   @ApiModelProperty(value = "Last time the condition was checked.")
-  public DateTime getLastProbeTime() {
+  public OffsetDateTime getLastProbeTime() {
     return lastProbeTime;
   }
 
-  public void setLastProbeTime(DateTime lastProbeTime) {
+  public void setLastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
   }
 
-  public KruiseAppsV1alpha1JobCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1JobCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -72,11 +73,11 @@ public class KruiseAppsV1alpha1JobCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transit from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ResourceDistributionCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1ResourceDistributionCondition.java
@@ -16,11 +16,12 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * ResourceDistributionCondition allows a row to be marked with additional information.
@@ -32,7 +33,7 @@ public class KruiseAppsV1alpha1ResourceDistributionCondition {
   private List<String> failedNamespace = null;
 
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("reason")
   private String reason = null;
@@ -69,7 +70,7 @@ public class KruiseAppsV1alpha1ResourceDistributionCondition {
     this.failedNamespace = failedNamespace;
   }
 
-  public KruiseAppsV1alpha1ResourceDistributionCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1ResourceDistributionCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -79,11 +80,11 @@ public class KruiseAppsV1alpha1ResourceDistributionCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "LastTransitionTime is the last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1StatefulSetCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1StatefulSetCondition.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * StatefulSetCondition describes the state of a statefulset at a certain point.
@@ -27,7 +28,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1StatefulSetCondition {
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -41,7 +42,7 @@ public class KruiseAppsV1alpha1StatefulSetCondition {
   @SerializedName("type")
   private String type = null;
 
-  public KruiseAppsV1alpha1StatefulSetCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1StatefulSetCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -51,11 +52,11 @@ public class KruiseAppsV1alpha1StatefulSetCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1SyncStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1SyncStatus.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * The first of all job has finished on this node. When a node is added to the cluster, we want to know the time when the node&#39;s image pulling is completed, and use it to trigger the operation of the upper system.
@@ -33,7 +34,7 @@ public class KruiseAppsV1alpha1SyncStatus {
   private String status = null;
 
   @SerializedName("syncAt")
-  private DateTime syncAt = null;
+  private OffsetDateTime syncAt = null;
 
   public KruiseAppsV1alpha1SyncStatus message(String message) {
     this.message = message;
@@ -71,7 +72,7 @@ public class KruiseAppsV1alpha1SyncStatus {
     this.status = status;
   }
 
-  public KruiseAppsV1alpha1SyncStatus syncAt(DateTime syncAt) {
+  public KruiseAppsV1alpha1SyncStatus syncAt(OffsetDateTime syncAt) {
     this.syncAt = syncAt;
     return this;
   }
@@ -81,11 +82,11 @@ public class KruiseAppsV1alpha1SyncStatus {
    * @return syncAt
   **/
   @ApiModelProperty(value = "")
-  public DateTime getSyncAt() {
+  public OffsetDateTime getSyncAt() {
     return syncAt;
   }
 
-  public void setSyncAt(DateTime syncAt) {
+  public void setSyncAt(OffsetDateTime syncAt) {
     this.syncAt = syncAt;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1UnitedDeploymentCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1UnitedDeploymentCondition.java
@@ -16,9 +16,10 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * UnitedDeploymentCondition describes current state of a UnitedDeployment.
@@ -27,7 +28,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1UnitedDeploymentCondition {
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -41,7 +42,7 @@ public class KruiseAppsV1alpha1UnitedDeploymentCondition {
   @SerializedName("type")
   private String type = null;
 
-  public KruiseAppsV1alpha1UnitedDeploymentCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1UnitedDeploymentCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -51,11 +52,11 @@ public class KruiseAppsV1alpha1UnitedDeploymentCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1WorkloadSpreadCondition.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1WorkloadSpreadCondition.java
@@ -15,9 +15,10 @@ package io.openkruise.client.models;
 
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * KruiseAppsV1alpha1WorkloadSpreadStatusConditions
@@ -25,7 +26,7 @@ import org.joda.time.DateTime;
 @Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2023-07-21T15:55:09.049+08:00")
 public class KruiseAppsV1alpha1WorkloadSpreadCondition {
   @SerializedName("lastTransitionTime")
-  private DateTime lastTransitionTime = null;
+  private OffsetDateTime lastTransitionTime = null;
 
   @SerializedName("message")
   private String message = null;
@@ -39,7 +40,7 @@ public class KruiseAppsV1alpha1WorkloadSpreadCondition {
   @SerializedName("type")
   private String type = null;
 
-  public KruiseAppsV1alpha1WorkloadSpreadCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public KruiseAppsV1alpha1WorkloadSpreadCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
@@ -49,11 +50,11 @@ public class KruiseAppsV1alpha1WorkloadSpreadCondition {
    * @return lastTransitionTime
   **/
   @ApiModelProperty(value = "Last time the condition transitioned from one status to another.")
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1WorkloadSpreadSubsetStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruiseAppsV1alpha1WorkloadSpreadSubsetStatus.java
@@ -16,13 +16,14 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * WorkloadSpreadSubsetStatus defines the observed state of subset
@@ -34,10 +35,10 @@ public class KruiseAppsV1alpha1WorkloadSpreadSubsetStatus {
   private List<KruiseAppsV1alpha1WorkloadSpreadCondition> conditions = null;
 
   @SerializedName("creatingPods")
-  private Map<String, DateTime> creatingPods = null;
+  private Map<String, OffsetDateTime> creatingPods = null;
 
   @SerializedName("deletingPods")
-  private Map<String, DateTime> deletingPods = null;
+  private Map<String, OffsetDateTime> deletingPods = null;
 
   @SerializedName("missingReplicas")
   private Integer missingReplicas = null;
@@ -74,14 +75,14 @@ public class KruiseAppsV1alpha1WorkloadSpreadSubsetStatus {
     this.conditions = conditions;
   }
 
-  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus creatingPods(Map<String, DateTime> creatingPods) {
+  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus creatingPods(Map<String, OffsetDateTime> creatingPods) {
     this.creatingPods = creatingPods;
     return this;
   }
 
-  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus putCreatingPodsItem(String key, DateTime creatingPodsItem) {
+  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus putCreatingPodsItem(String key, OffsetDateTime creatingPodsItem) {
     if (this.creatingPods == null) {
-      this.creatingPods = new HashMap<String, DateTime>();
+      this.creatingPods = new HashMap<String, OffsetDateTime>();
     }
     this.creatingPods.put(key, creatingPodsItem);
     return this;
@@ -92,22 +93,22 @@ public class KruiseAppsV1alpha1WorkloadSpreadSubsetStatus {
    * @return creatingPods
   **/
   @ApiModelProperty(value = "CreatingPods contains information about pods whose creation was processed by the webhook handler but not yet been observed by the WorkloadSpread controller. A pod will be in this map from the time when the webhook handler processed the creation request to the time when the pod is seen by controller. The key in the map is the name of the pod and the value is the time when the webhook handler process the creation request. If the real creation didn't happen and a pod is still in this map, it will be removed from the list automatically by WorkloadSpread controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod creations.")
-  public Map<String, DateTime> getCreatingPods() {
+  public Map<String, OffsetDateTime> getCreatingPods() {
     return creatingPods;
   }
 
-  public void setCreatingPods(Map<String, DateTime> creatingPods) {
+  public void setCreatingPods(Map<String, OffsetDateTime> creatingPods) {
     this.creatingPods = creatingPods;
   }
 
-  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus deletingPods(Map<String, DateTime> deletingPods) {
+  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus deletingPods(Map<String, OffsetDateTime> deletingPods) {
     this.deletingPods = deletingPods;
     return this;
   }
 
-  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus putDeletingPodsItem(String key, DateTime deletingPodsItem) {
+  public KruiseAppsV1alpha1WorkloadSpreadSubsetStatus putDeletingPodsItem(String key, OffsetDateTime deletingPodsItem) {
     if (this.deletingPods == null) {
-      this.deletingPods = new HashMap<String, DateTime>();
+      this.deletingPods = new HashMap<String, OffsetDateTime>();
     }
     this.deletingPods.put(key, deletingPodsItem);
     return this;
@@ -118,11 +119,11 @@ public class KruiseAppsV1alpha1WorkloadSpreadSubsetStatus {
    * @return deletingPods
   **/
   @ApiModelProperty(value = "DeletingPods is similar with CreatingPods and it contains information about pod deletion.")
-  public Map<String, DateTime> getDeletingPods() {
+  public Map<String, OffsetDateTime> getDeletingPods() {
     return deletingPods;
   }
 
-  public void setDeletingPods(Map<String, DateTime> deletingPods) {
+  public void setDeletingPods(Map<String, OffsetDateTime> deletingPods) {
     this.deletingPods = deletingPods;
   }
 

--- a/src/main/java/io/openkruise/client/models/KruisePolicyV1alpha1PodUnavailableBudgetStatus.java
+++ b/src/main/java/io/openkruise/client/models/KruisePolicyV1alpha1PodUnavailableBudgetStatus.java
@@ -16,11 +16,12 @@ package io.openkruise.client.models;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
-import org.joda.time.DateTime;
 
 /**
  * PodUnavailableBudgetStatus defines the observed state of PodUnavailableBudget
@@ -35,7 +36,7 @@ public class KruisePolicyV1alpha1PodUnavailableBudgetStatus {
   private Integer desiredAvailable = null;
 
   @SerializedName("disruptedPods")
-  private Map<String, DateTime> disruptedPods = null;
+  private Map<String, OffsetDateTime> disruptedPods = null;
 
   @SerializedName("observedGeneration")
   private Long observedGeneration = null;
@@ -47,7 +48,7 @@ public class KruisePolicyV1alpha1PodUnavailableBudgetStatus {
   private Integer unavailableAllowed = null;
 
   @SerializedName("unavailablePods")
-  private Map<String, DateTime> unavailablePods = null;
+  private Map<String, OffsetDateTime> unavailablePods = null;
 
   public KruisePolicyV1alpha1PodUnavailableBudgetStatus currentAvailable(Integer currentAvailable) {
     this.currentAvailable = currentAvailable;
@@ -85,14 +86,14 @@ public class KruisePolicyV1alpha1PodUnavailableBudgetStatus {
     this.desiredAvailable = desiredAvailable;
   }
 
-  public KruisePolicyV1alpha1PodUnavailableBudgetStatus disruptedPods(Map<String, DateTime> disruptedPods) {
+  public KruisePolicyV1alpha1PodUnavailableBudgetStatus disruptedPods(Map<String, OffsetDateTime> disruptedPods) {
     this.disruptedPods = disruptedPods;
     return this;
   }
 
-  public KruisePolicyV1alpha1PodUnavailableBudgetStatus putDisruptedPodsItem(String key, DateTime disruptedPodsItem) {
+  public KruisePolicyV1alpha1PodUnavailableBudgetStatus putDisruptedPodsItem(String key, OffsetDateTime disruptedPodsItem) {
     if (this.disruptedPods == null) {
-      this.disruptedPods = new HashMap<String, DateTime>();
+      this.disruptedPods = new HashMap<String, OffsetDateTime>();
     }
     this.disruptedPods.put(key, disruptedPodsItem);
     return this;
@@ -103,11 +104,11 @@ public class KruisePolicyV1alpha1PodUnavailableBudgetStatus {
    * @return disruptedPods
   **/
   @ApiModelProperty(value = "DisruptedPods contains information about pods whose eviction or deletion was processed by the API handler but has not yet been observed by the PodUnavailableBudget.")
-  public Map<String, DateTime> getDisruptedPods() {
+  public Map<String, OffsetDateTime> getDisruptedPods() {
     return disruptedPods;
   }
 
-  public void setDisruptedPods(Map<String, DateTime> disruptedPods) {
+  public void setDisruptedPods(Map<String, OffsetDateTime> disruptedPods) {
     this.disruptedPods = disruptedPods;
   }
 
@@ -165,14 +166,14 @@ public class KruisePolicyV1alpha1PodUnavailableBudgetStatus {
     this.unavailableAllowed = unavailableAllowed;
   }
 
-  public KruisePolicyV1alpha1PodUnavailableBudgetStatus unavailablePods(Map<String, DateTime> unavailablePods) {
+  public KruisePolicyV1alpha1PodUnavailableBudgetStatus unavailablePods(Map<String, OffsetDateTime> unavailablePods) {
     this.unavailablePods = unavailablePods;
     return this;
   }
 
-  public KruisePolicyV1alpha1PodUnavailableBudgetStatus putUnavailablePodsItem(String key, DateTime unavailablePodsItem) {
+  public KruisePolicyV1alpha1PodUnavailableBudgetStatus putUnavailablePodsItem(String key, OffsetDateTime unavailablePodsItem) {
     if (this.unavailablePods == null) {
-      this.unavailablePods = new HashMap<String, DateTime>();
+      this.unavailablePods = new HashMap<String, OffsetDateTime>();
     }
     this.unavailablePods.put(key, unavailablePodsItem);
     return this;
@@ -183,11 +184,11 @@ public class KruisePolicyV1alpha1PodUnavailableBudgetStatus {
    * @return unavailablePods
   **/
   @ApiModelProperty(value = "UnavailablePods contains information about pods whose specification changed(inplace-update pod), once pod is available(consistent and ready) again, it will be removed from the list.")
-  public Map<String, DateTime> getUnavailablePods() {
+  public Map<String, OffsetDateTime> getUnavailablePods() {
     return unavailablePods;
   }
 
-  public void setUnavailablePods(Map<String, DateTime> unavailablePods) {
+  public void setUnavailablePods(Map<String, OffsetDateTime> unavailablePods) {
     this.unavailablePods = unavailablePods;
   }
 

--- a/src/main/java/io/openkruise/client/models/ProbeHandler.java
+++ b/src/main/java/io/openkruise/client/models/ProbeHandler.java
@@ -5,9 +5,8 @@ import io.kubernetes.client.openapi.models.V1HTTPGetAction;
 import io.kubernetes.client.openapi.models.V1TCPSocketAction;
 
 /**
+ * ProbeHandler defines a specific action that should be taken, replaced V1Handler temporarily.
  * @author mowu.wd
- * @date 2024-07-02 19:55
- * @desc
  */
 public class ProbeHandler {
 

--- a/src/main/java/io/openkruise/client/models/ProbeHandler.java
+++ b/src/main/java/io/openkruise/client/models/ProbeHandler.java
@@ -1,0 +1,43 @@
+package io.openkruise.client.models;
+
+import io.kubernetes.client.openapi.models.V1ExecAction;
+import io.kubernetes.client.openapi.models.V1HTTPGetAction;
+import io.kubernetes.client.openapi.models.V1TCPSocketAction;
+
+/**
+ * @author mowu.wd
+ * @date 2024-07-02 19:55
+ * @desc
+ */
+public class ProbeHandler {
+
+    private V1ExecAction exec;
+
+    private V1HTTPGetAction httpGet;
+
+    private V1TCPSocketAction tcpSocket;
+
+    public V1ExecAction getExec() {
+        return exec;
+    }
+
+    public void setExec(V1ExecAction exec) {
+        this.exec = exec;
+    }
+
+    public V1HTTPGetAction getHttpGet() {
+        return httpGet;
+    }
+
+    public void setHttpGet(V1HTTPGetAction httpGet) {
+        this.httpGet = httpGet;
+    }
+
+    public V1TCPSocketAction getTcpSocket() {
+        return tcpSocket;
+    }
+
+    public void setTcpSocket(V1TCPSocketAction tcpSocket) {
+        this.tcpSocket = tcpSocket;
+    }
+}


### PR DESCRIPTION
1. Convert all datetime to offset datetime.
2. Upgrade the Kubernetes Java client to version 18.0.1.
3. Synchronize the Golang version, temporarily replace V1Handler with ProbeHandler.